### PR TITLE
Disable logging for health endpoint

### DIFF
--- a/src/self_description_creator.py
+++ b/src/self_description_creator.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import shutil
 from logging.config import dictConfig
@@ -50,6 +51,10 @@ def init_app():
     """
     Initialize the core application.
     """
+    class HealthCheckFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            return record.getMessage().find("/health") == -1
+
     dictConfig({
         'version': 1,
         'formatters': {'default': {
@@ -66,6 +71,7 @@ def init_app():
         }
     })
 
+    logging.getLogger("werkzeug").addFilter(HealthCheckFilter())
     app = Flask(__name__)
 
     # Flask-internal logger has been disabled since it logs every request by default which pollutes the log output

--- a/src/version.py
+++ b/src/version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = '0.1.0'
+__version__ = '0.2.0'


### PR DESCRIPTION
The changes disable logging for the /health endpoint which pollutes the log output when running inside a cluster.