### PR TITLE
add #JWK2020-RSA to the verificationMethod

### DIFF
--- a/src/self_description_processor.py
+++ b/src/self_description_processor.py
@@ -106,7 +106,7 @@ class SelfDescriptionProcessor:
         proof = {
             "type": "JsonWebSignature2020",
             "created": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-            "verificationMethod": self.__credential_issuer,
+            "verificationMethod": self.__credential_issuer+"#JWK2020-RSA",
             "proofPurpose": "assertionMethod",
         }
         # Important info (legacy catalogue): The @context provided in the proof object is required to successfully perform the


### PR DESCRIPTION
Currently we add the postfix #JWK2020-RSA in general, since all our dids have this verification method.

If there will be a requirement for having verious verification methods, we need to think about how we make it configurable or as an argument along the payload (which would make more sense)